### PR TITLE
Add ignore webpack plugin for moment locales

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -76,7 +76,8 @@ module.exports = {
                 new webpack.ProvidePlugin({
                     '$': 'jquery',
                     'Popper': 'popper.js',
-                })
+                }),
+                new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
             ],
             /*
             ** Run ESLint on save


### PR DESCRIPTION
This removes about ~150kb of unused code from the bundle size, since the codebase does not use any locales. 