### PR TITLE
fix: mod panel game default to details as expected

### DIFF
--- a/pages/mod/game.vue
+++ b/pages/mod/game.vue
@@ -3,11 +3,7 @@
         <PanelHeader :title="startDate" :subtitle="`@ ${startTime} UTC`">
             <ButtonGroup>
                 <Button to="/mod/games" class="outline muted">Back</Button>
-                <Button
-                    v-if="isActive && !isEnded && !isScheduled"
-                    class="danger"
-                    :async-click="endGame"
-                >End</Button>
+                <Button v-if="isActive && !isEnded && !isScheduled" class="danger" :async-click="endGame">End</Button>
                 <Button v-if="!isActive" class="primary" :async-click="activate">Activate</Button>
                 <Button v-if="viewingDetailsPage" class="primary" :async-click="save">Save</Button>
                 <Button v-if="user.role === 'ADMIN'" class="danger" :async-click="remove">Delete</Button>
@@ -15,14 +11,13 @@
         </PanelHeader>
 
         <Tabs>
-            <nuxt-link :to="'/mod/game/details?game=' + game.id">Details</nuxt-link>
-            <nuxt-link :to="'/mod/game/brief?game=' + game.id">Brief</nuxt-link>
+            <nuxt-link :to="`/mod/game/details?game=${game.id}`">Details</nuxt-link>
+            <nuxt-link :to="`/mod/game/brief?game=${game.id}`">Brief</nuxt-link>
         </Tabs>
 
         <nuxt/>
     </div>
 </template>
-
 
 <script>
 import moment from 'moment';

--- a/pages/mod/games.vue
+++ b/pages/mod/games.vue
@@ -19,15 +19,15 @@
             <tr v-for="game in games" :key="game.id">
                 <td>{{ game.createdAt | moment('MM/DD/YYYY') }}</td>
                 <td>
-                    <span
-                        :class="['mod-status', nameFromStatus(game.status).toLowerCase()]"
-                    >{{ nameFromStatus(game.status) }}</span>
+                    <span :class="['mod-status', nameFromStatus(game.status).toLowerCase()]">{{
+                        nameFromStatus(game.status)
+                    }}</span>
                 </td>
                 <td>{{ game.season }}</td>
                 <td>{{ game.title }}</td>
                 <td>{{ game.mode }}</td>
                 <td>
-                    <Button :to="'/mod/game/brief?game=' + game.id" class="link">Edit</Button>
+                    <Button :to="'/mod/game/details?game=' + game.id" class="link">Edit</Button>
                 </td>
             </tr>
         </Table>
@@ -35,7 +35,6 @@
         <Pagination/>
     </div>
 </template>
-
 
 <script>
 import CreateGameModal from '@/components/modal/CreateGameModal';
@@ -76,7 +75,6 @@ export default {
     },
 };
 </script>
-
 
 <style lang="scss" scoped>
 @import 'utils.scss';


### PR DESCRIPTION
### General
When on the moderation panel and navigating into a game, it defaults to the details page but shows the brief, shifting to the details page requires clicking the brief and then again on the details page. This change ensures that the game page shows the correct tab when first entering.

