### PR TITLE
API Version, Non-negative countdown, Cropping

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,24 +33,7 @@
         "no-restricted-globals": "off",
         "vue/no-use-v-if-with-v-for": "warn",
         "global-require": "off",
-        "vue/html-closing-bracket-spacing": [
-            "error",
-            {
-                "startTag": "never",
-                "endTag": "never",
-                "selfClosingTag": "never"
-            }
-        ],
-        "vue/html-self-closing": [
-            "error",
-            {
-                "html": {
-                    "void": "never",
-                    "normal": "never",
-                    "component": "always"
-                }
-            }
-        ],
+
         "max-len": [
             "error",
             120,

--- a/components/FileChooser.vue
+++ b/components/FileChooser.vue
@@ -1,10 +1,9 @@
 <template>
     <div>
-        <input ref="chooser" type="file" style="display: none;" @change="change">
+        <input ref="chooser" type="file" style="display: none;" @change="change" />
         <slot :update="slotClicked"></slot>
     </div>
 </template>
-
 
 <script>
 export default {
@@ -13,6 +12,7 @@ export default {
         slotClicked() {
             this.$refs.chooser.click();
         },
+
         change() {
             const reader = new FileReader();
             const file = this.$refs.chooser.files[0];

--- a/components/game/LargeGameDetail.vue
+++ b/components/game/LargeGameDetail.vue
@@ -5,9 +5,7 @@
                 <div class="banner__meta">
                     <span class="banner__date">{{ game.startTime | moment('M/DD/YYYY') }}</span>
                     <h2 class="banner__gamemode">{{ game.mode }}</h2>
-                    <div
-                        class="banner__versus"
-                    >{{ teams[0].numPlayers }} VS {{ teams[1].numPlayers }}</div>
+                    <div class="banner__versus">{{ teams[0].numPlayers }} VS {{ teams[1].numPlayers }}</div>
                 </div>
                 <ButtonIcon
                     v-show="game.videoUrl"
@@ -15,7 +13,8 @@
                     target="_blank"
                     icon="fab fa-youtube"
                     class="youtube"
-                >Watch on YouTube</ButtonIcon>
+                    >Watch on YouTube</ButtonIcon
+                >
             </div>
         </Row>
 
@@ -41,26 +40,22 @@
             <h3>{{ game.title }}</h3>
         </SubScore>
 
-        <SubScore
-            title="Objectives"
-            :blueScore="teams[0].scores.objectives"
-            :redScore="teams[1].scores.objectives"
-        >
+        <SubScore title="Objectives" :blueScore="teams[0].scores.objectives" :redScore="teams[1].scores.objectives">
             <ul class="objectives">
                 <li
                     v-for="objective in game.objectives"
                     :key="objective.id"
                     class="objectives__item"
-                    :class="{bonus: objective.isBonus }"
+                    :class="{ bonus: objective.isBonus }"
                 >
                     <div
                         class="objectives__square team-blue"
-                        :class="{active: teamCompletedObjective(0, objective) }"
+                        :class="{ active: teamCompletedObjective(0, objective) }"
                     ></div>
                     <span class="objectives__obj">{{ objective.description }}</span>
                     <div
                         class="objectives__square team-red"
-                        :class="{active: teamCompletedObjective(1, objective) }"
+                        :class="{ active: teamCompletedObjective(1, objective) }"
                     ></div>
                 </li>
             </ul>
@@ -70,7 +65,6 @@
         <VoteBox :game="game" category="ux"/>
     </div>
 </template>
-
 
 <script>
 import VoteBox from '@/components/game/VoteBox';
@@ -89,6 +83,11 @@ export default {
             type: Object,
             required: true,
         },
+        includePlayers: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
     },
     methods: {
         getLanguageByGamePlayer,
@@ -96,7 +95,6 @@ export default {
     },
 };
 </script>
-
 
 <style lang="scss" scoped>
 @import 'utils.scss';

--- a/components/game/NextShowing.vue
+++ b/components/game/NextShowing.vue
@@ -1,34 +1,37 @@
 <template>
     <HomeCard v-if="latestSchedule" title="Next Showing">
+        <div v-if="updateTimeInterval === null" class="now-showing">
+            <div class="next-showing__time">Any Minute now!</div>
+        </div>
+
         <ul id="countdown" class="countdown">
             <li id="days" class="countdown__item">
-                <div class="countdown__number">{{ timeDifference.days}}</div>
+                <div class="countdown__number">{{ timeDifference.days }}</div>
                 <div class="countdown__label">Days</div>
             </li>
             <li id="hours" class="countdown__item">
-                <div class="countdown__number">{{ timeDifference.hours}}</div>
+                <div class="countdown__number">{{ timeDifference.hours }}</div>
                 <div class="countdown__label">Hours</div>
             </li>
             <li id="minutes" class="countdown__item">
-                <div class="countdown__number">{{ timeDifference.minutes}}</div>
+                <div class="countdown__number">{{ timeDifference.minutes }}</div>
                 <div class="countdown__label">Minutes</div>
             </li>
             <li id="seconds" class="countdown__item">
-                <div class="countdown__number">{{ timeDifference.seconds}}</div>
+                <div class="countdown__number">{{ timeDifference.seconds }}</div>
                 <div class="countdown__label">Seconds</div>
             </li>
         </ul>
         <div class="next-showing">
             <div class="next-showing__date">{{ latestSchedule.startTime | moment('dddd, MMMM DD') }}</div>
-            <div class="next-showing__time">{{ latestSchedule.startTime | moment('H:mm')}} (UTC)</div>
+            <div class="next-showing__time">{{ latestSchedule.startTime | moment('H:mm') }} (UTC)</div>
         </div>
 
         <div slot="actions">
-            <RegistrationButtons :schedule="latestSchedule"/>
+            <RegistrationButtons :schedule="latestSchedule" />
         </div>
     </HomeCard>
 </template>
-
 
 <script>
 import moment from 'moment';
@@ -42,6 +45,8 @@ export default {
     data: () => {
         return {
             timeDifference: {},
+            updateTimeInterval: null,
+            units: ['days', 'hours', 'minutes', 'seconds'],
         };
     },
     computed: {
@@ -55,30 +60,38 @@ export default {
         },
     },
     mounted() {
+        this.updateTimeInterval = setInterval(this.updateTime.bind(this), 1000);
         this.updateTime();
-
-        setInterval(this.updateTime.bind(this), 1000);
     },
     methods: {
-        updateTime() {
-            const diff = moment.utc(this.latestSchedule.startTime).diff(moment());
-            const units = ['days', 'hours', 'minutes', 'seconds'];
+        resetTime() {
+            clearInterval(this.updateTimeInterval);
+            const updatedTimeDifference = {};
 
-            const updated = {};
-
-            units.forEach((unit) => {
-                updated[unit] = moment
-                    .duration(diff)
-                    [unit]()
-                    .toFixed(0);
+            this.units.forEach((value) => {
+                updatedTimeDifference[value] = 0;
             });
 
-            this.timeDifference = updated;
+            this.timeDifference = updatedTimeDifference;
+            this.updateTimeInterval = null;
+        },
+
+        updateTime() {
+            const delta = moment.utc(this.latestSchedule.startTime).diff(moment());
+            if (delta <= 0) return this.resetTime();
+
+            const updatedTimeDifference = {};
+
+            this.units.forEach((unit) => {
+                const unitTime = moment.duration(delta)[unit]();
+                updatedTimeDifference[unit] = unitTime.toFixed(0);
+            });
+
+            this.timeDifference = updatedTimeDifference;
         },
     },
 };
 </script>
-
 
 <style lang="scss" scoped>
 @import 'utils.scss';
@@ -105,6 +118,12 @@ export default {
         color: $text-color-secondary;
         text-transform: uppercase;
     }
+}
+
+.now-showing {
+    width: 100%;
+    margin-bottom: 0px;
+    margin-top: -25px;
 }
 
 .next-showing {

--- a/components/game/NextShowing.vue
+++ b/components/game/NextShowing.vue
@@ -1,7 +1,7 @@
 <template>
     <HomeCard v-if="latestSchedule" title="Next Showing">
         <div v-if="updateTimeInterval === null" class="now-showing">
-            <div class="next-showing__time">Any Minute now!</div>
+            <div class="next-showing__time">Any Minute Now!</div>
         </div>
 
         <ul id="countdown" class="countdown">

--- a/components/mod/ModSidebar.vue
+++ b/components/mod/ModSidebar.vue
@@ -3,48 +3,32 @@
         <h6>Main</h6>
         <ul>
             <li>
-                <nuxt-link to="/mod/dashboard">
-                    <i class="fa fa-tachometer"></i>Dashboard
-                </nuxt-link>
+                <nuxt-link to="/mod/dashboard"> <i class="fa fa-tachometer"></i>Dashboard </nuxt-link>
             </li>
             <li>
-                <nuxt-link to="/mod/users" class="disabled">
-                    <i class="fa fa-user"></i>Users
-                </nuxt-link>
+                <nuxt-link to="/mod/users" class="disabled"> <i class="fa fa-user"></i>Users </nuxt-link>
             </li>
             <li>
-                <nuxt-link to="/mod/teams" class="disabled">
-                    <i class="fa fa-users"></i>Teams
-                </nuxt-link>
+                <nuxt-link to="/mod/teams" class="disabled"> <i class="fa fa-users"></i>Teams </nuxt-link>
             </li>
             <li>
-                <nuxt-link to="/mod/schedules">
-                    <i class="fa fa-calendar"></i>Schedules
-                </nuxt-link>
+                <nuxt-link to="/mod/schedules"> <i class="fa fa-calendar"></i>Schedules </nuxt-link>
             </li>
             <li>
-                <nuxt-link to="/mod/games">
-                    <i class="fa fa-gamepad"></i>Games
-                </nuxt-link>
+                <nuxt-link to="/mod/games"> <i class="fa fa-gamepad"></i>Games </nuxt-link>
             </li>
             <li>
-                <nuxt-link to="/mod/tournaments">
-                    <i class="fa fa-trophy"></i>Tournaments
-                </nuxt-link>
+                <nuxt-link to="/mod/tournaments"> <i class="fa fa-trophy"></i>Tournaments </nuxt-link>
             </li>
             <li>
-                <nuxt-link to="/mod/blogs" class="disabled">
-                    <i class="fa fa-newspaper"></i>Blog
-                </nuxt-link>
+                <nuxt-link to="/mod/blogs" class="disabled"> <i class="fa fa-newspaper"></i>Blog </nuxt-link>
             </li>
         </ul>
 
         <h6>More</h6>
         <ul>
             <li>
-                <nuxt-link to="#" class="disabled">
-                    <i class="fa fa-file-alt"></i>Mod Doc
-                </nuxt-link>
+                <nuxt-link to="#" class="disabled"> <i class="fa fa-file-alt"></i>Mod Doc </nuxt-link>
             </li>
         </ul>
 
@@ -52,28 +36,51 @@
         <ul class="list-info">
             <li>
                 <nuxt-link to="#">
-                    <Progress title="Server Usage" :progress="30 + '%'" color="primary"/>
+                    <Progress title="Server Usage" :progress="30 + '%'" color="primary" />
                 </nuxt-link>
             </li>
             <li>
                 <nuxt-link to="#">
-                    <Progress title="GitHub Issues" :progress="30 + '%'" color="yellow"/>
+                    <Progress title="GitHub Issues" :progress="30 + '%'" color="yellow" />
                 </nuxt-link>
             </li>
         </ul>
+
+        <h6>information</h6>
+        <div class="information">
+            <div>
+                API: <span>v{{ serverVersion }}</span>
+            </div>
+            <div>
+                Status: <span :class="apiStatusColor">{{ serverStatus }}</span>
+            </div>
+        </div>
     </div>
 </template>
 
-
 <script>
+import { mapGetters } from 'vuex';
 import Progress from '@/components/form/Progress';
 
 export default {
     name: 'ModSidebar',
     components: { Progress },
+
+    data() {
+        return {
+            apiStatusColor: 'information__healthy',
+        };
+    },
+
+    computed: {
+        ...mapGetters({ serverVersion: 'server/version', serverStatus: 'server/status' }),
+    },
+
+    mounted() {
+        this.apiStatusColor = `information__${this.serverStatus}`.toLowerCase();
+    },
 };
 </script>
-
 
 <style lang="scss" scoped>
 @import 'utils.scss';
@@ -129,6 +136,34 @@ export default {
             margin-right: 20px;
             text-align: center;
         }
+    }
+}
+
+.information {
+    padding: 10px $s-space;
+
+    h5 {
+        margin-bottom: $xs-space;
+        font-weight: $font-weight-bold;
+    }
+
+    div {
+        margin-bottom: 10px;
+        margin-top: 0px;
+        font-size: $font-size-base;
+        line-height: 1.3;
+    }
+
+    &__healthy {
+        color: $success-color;
+    }
+
+    &__degraded {
+        color: $warning-color;
+    }
+
+    &__error {
+        color: $danger-color;
     }
 }
 </style>

--- a/components/modal/CropperModal.vue
+++ b/components/modal/CropperModal.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div style="height: 400px;">
-            <img ref="cropper" :src="data" @load="imageLoad">
+            <img ref="cropper" :src="data" @load="imageLoad" />
         </div>
 
         <ButtonGroup class="modal__actions">
@@ -9,7 +9,6 @@
         </ButtonGroup>
     </div>
 </template>
-
 
 <script>
 import Cropper from 'cropperjs';
@@ -43,6 +42,7 @@ export default {
                     resolve(res);
                 }, 'image/jpeg');
             });
+
             this.close(data);
         },
     },

--- a/pages/competitor/register.vue
+++ b/pages/competitor/register.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="CompetitorRegistration">
-        <PageBanner title="Compete in DevWars" type="competitor"/>
+        <PageBanner title="Compete in DevWars" type="competitor" />
 
         <div class="footer-offset">
             <Container>
@@ -12,7 +12,7 @@
                                 label="First Name"
                                 class="group"
                                 required
-                                @input="e => change('profile.firstName', e)"
+                                @input="(e) => change('profile.firstName', e)"
                             />
                         </Column>
                         <Column :sm="6">
@@ -21,7 +21,7 @@
                                 label="Last Name"
                                 class="group"
                                 required
-                                @input="e => change('profile.lastName', e)"
+                                @input="(e) => change('profile.lastName', e)"
                             />
                         </Column>
                     </Row>
@@ -67,16 +67,8 @@
                             </Row>-->
                         </Column>
                         <Column :md="3">
-                            <Select
-                                v-model="sex"
-                                label="Sex"
-                                @change="e => change('profile.sex', e)"
-                            >
-                                <option
-                                    v-for="(sex, index) in sexes"
-                                    :key="sex"
-                                    :value="index"
-                                >{{ sex }}</option>
+                            <Select v-model="sex" label="Sex" @change="(e) => change('profile.sex', e)">
+                                <option v-for="(sex, index) in sexes" :key="sex" :value="index">{{ sex }}</option>
                             </Select>
                         </Column>
                         <Column :sm="3">
@@ -85,7 +77,7 @@
                                 label="Select Country"
                                 class="group"
                                 required
-                                @change="e => change('profile.country', e)"
+                                @change="(e) => change('profile.country', e)"
                             >
                                 <option v-for="country in countries" :key="country">{{ country }}</option>
                             </Select>
@@ -98,22 +90,19 @@
                                 v-model="profile.company"
                                 label="Company"
                                 class="group"
-                                @input="e => change('profile.company', e)"
+                                @input="(e) => change('profile.company', e)"
                             />
                         </Column>
                     </Row>
                 </Card>
 
                 <Card class="plain dark" title="Skill Assessment">
-                    <LanguageSkills
-                        :profile="profile"
-                        @change="e => change('profile.skills', e.values)"
-                    />
+                    <LanguageSkills :profile="profile" @change="(e) => change('profile.skills', e.values)" />
                 </Card>
 
                 <Card class="plain dark" title="Requirements">
                     <div>
-                        <ConnectToDiscord/>
+                        <ConnectToDiscord />
                     </div>
 
                     <p>A microphone is required to play in DevWars to communicate with your team during a game.</p>
@@ -122,7 +111,7 @@
                         name="has-microphone"
                         class="group"
                         required
-                        @input="e => hasMic = e"
+                        @input="(e) => (hasMic = e)"
                     />
                 </Card>
 
@@ -133,7 +122,6 @@
         </div>
     </div>
 </template>
-
 
 <script>
 // import moment from 'moment';
@@ -267,9 +255,7 @@ export default {
                     skills: finalSkills,
                     // dob: date,
                 };
-                console.log(userProfile);
                 await this.$axios.patch(`/user/${this.user.id}/profile`, userProfile);
-                console.log('DID THE PATCH');
 
                 if (this.schedule) {
                     await this.$store.dispatch('game/apply', this.schedule);
@@ -289,7 +275,6 @@ export default {
     },
 };
 </script>
-
 
 <style lang="scss" scoped>
 @import 'utils.scss';

--- a/pages/games.vue
+++ b/pages/games.vue
@@ -2,18 +2,16 @@
     <Container class="fluid">
         <Column :sm="3" class="sidebar no-gutter">
             <Tabs class="fluid invert">
-                <nuxt-link
-                    v-for="current in seasons"
-                    :key="current"
-                    :to="'/games?season=' + current"
-                >Season {{ current }}</nuxt-link>
+                <nuxt-link v-for="current in seasons" :key="current" :to="'/games?season=' + current"
+                    >Season {{ current }}</nuxt-link
+                >
             </Tabs>
 
             <div
                 v-for="game in games"
                 :key="game.id"
                 class="game"
-                :class="{active: viewing && viewing.id === game.id}"
+                :class="{ active: viewing && viewing.id === game.id }"
                 @click="view(game)"
             >
                 <div class="meta">
@@ -28,11 +26,10 @@
         </Column>
 
         <Column :sm="9" class="view">
-            <LargeGameDetail v-if="viewing" :game="viewing"/>
+            <LargeGameDetail v-if="viewing" :game="viewing" :includePlayers="includePlayers"/>
         </Column>
     </Container>
 </template>
-
 
 <script>
 import Http from '../services/Http';
@@ -51,6 +48,7 @@ export default {
             season: 3,
             games: [],
             viewing: null,
+            includePlayers: true,
         };
     },
 
@@ -63,7 +61,7 @@ export default {
                 this.games = await Http.for('games/season').get(this.season);
 
                 if (!this.$route.query.game) {
-                    this.viewing = await Http.for('games').get(this.games[0].id);
+                    this.viewing = await Http.for('games').get(`${this.games[0].id}?players=${this.includePlayers}`);
                 }
             },
         },
@@ -72,7 +70,7 @@ export default {
             immediate: true,
             async handler(newGame) {
                 if (newGame) {
-                    this.viewing = await Http.for('games').get(newGame);
+                    this.viewing = await Http.for('games').get(`${newGame}?players=${this.includePlayers}`);
                 }
             },
         },
@@ -88,7 +86,6 @@ export default {
     },
 };
 </script>
-
 
 <style lang="scss" scoped>
 @import 'utils.scss';

--- a/pages/settings/profile.vue
+++ b/pages/settings/profile.vue
@@ -84,8 +84,8 @@
                     </Column>
 
                     <Column :md="4">
-                        <Select v-model="sex" label="Sex" @input="updateForm({ values: $event, key: 'sex' })">
-                            <option v-for="(sex, index) in sexes" :key="sex" :value="index">{{ sex }}</option>
+                        <Select v-model="sex" label="Sex" @input="updateForm({ values: Number($event), key: 'sex' })">
+                            <option v-for="(sex, index) in sexes" :key="index" :value="index">{{ sex }}</option>
                         </Select>
                     </Column>
                 </Row>
@@ -122,12 +122,12 @@
                     @input="updateForm({ values: $event, key: 'forHire' })"
                 />
 
-                <LanguageSkills :profile="profile" @change="updateForm"/>
+                <LanguageSkills :profile="profile" @change="updateForm" />
             </Column>
             <Column :md="4">
                 <h3>Avatar</h3>
 
-                <Avatar v-if="user" :user="user" class="xl"/>
+                <Avatar v-if="user" :user="user" class="xl" />
 
                 <FileChooser @change="crop">
                     <template #default="{update}">
@@ -195,6 +195,7 @@ export default {
 
     methods: {
         updateForm({ values, key }) {
+            console.log(`values`, values, 'key', key);
             this.$store.commit('user/profileUpdate', { key, values });
         },
 

--- a/pages/settings/profile.vue
+++ b/pages/settings/profile.vue
@@ -195,14 +195,12 @@ export default {
 
     methods: {
         updateForm({ values, key }) {
-            console.log(`values`, values, 'key', key);
             this.$store.commit('user/profileUpdate', { key, values });
         },
 
         async crop(result) {
-            const [cropped] = await this.$open(CropperModal, { data: result });
-
-            this.$store.dispatch('users/avatar', cropped);
+            const cropped = await this.$open(CropperModal, { data: result });
+            this.$store.dispatch('user/avatar', cropped);
         },
 
         async save() {

--- a/store/index.js
+++ b/store/index.js
@@ -5,6 +5,8 @@ export const mutations = {};
 export const actions = {
     async nuxtServerInit({ dispatch }) {
         await Promise.all([
+            dispatch('server/health'),
+
             // dispatch('user/refreshUserCount'),
             dispatch('user/refresh'),
 

--- a/store/server.js
+++ b/store/server.js
@@ -1,0 +1,27 @@
+import Http from '../services/Http';
+
+export const state = () => ({
+    server: {},
+});
+
+export const getters = {
+    version(state) {
+        return state.server.version;
+    },
+    status(state) {
+        return state.server.status;
+    },
+};
+
+export const mutations = {
+    badges(state, server) {
+        state.server = server;
+    },
+};
+
+export const actions = {
+    async health({ commit }) {
+        const server = await Http.for('health').get();
+        commit('badges', server);
+    },
+};

--- a/utils/mixins.js
+++ b/utils/mixins.js
@@ -41,28 +41,32 @@ export const usersFromGame = {
     data: () => ({
         users: {},
     }),
+
     watch: {
         game() {
             this.getUsersFromGame();
         },
     },
+
     mounted() {
         this.getUsersFromGame();
     },
     methods: {
         playersWithUser(players) {
             const result = [];
+
             for (const player of Object.values(players)) {
                 const user = this.users[player.id];
-                if (user) {
-                    result.push({ ...user, ...player });
-                }
+                if (user) result.push({ ...user, ...player });
             }
 
             return result;
         },
 
         async getUsersFromGame() {
+            this.users = this.includePlayers ? this.game.players : this.users;
+            if (Object.keys(this.users).length >= 1) return;
+
             const standardPlayers = Object.values(this.game.players).filter((e) => e.id !== 0);
             const competitorPlayers = Object.values(this.game.players).filter((e) => e.id === 0);
 


### PR DESCRIPTION
#### Overview 📚

#### Games includes
When gathering a game for the large game overview, includePlayers is specified by default to remove the need of gathering the related players information each time.

This reduces the request count from 1 + player total to 1.

![image](https://user-images.githubusercontent.com/12329422/72287457-0270ae00-363f-11ea-8f12-4c604340d72b.png)

vs 

![image](https://user-images.githubusercontent.com/12329422/72287508-16b4ab00-363f-11ea-8a6c-1cb0e9f9c9f4.png)

#### Countdown
When the countdown hits zero and the stream/game is not currently active, don't go negative and ensure to display a starting soon message.

![image](https://user-images.githubusercontent.com/12329422/72287379-dc4b0e00-363e-11ea-9329-7b9ae85f6540.png)

### API Status (Moderation panel)

On the moderation side bar, api version and health is now reported. This is done by calling into the /health endpoint which returns the version and status.

![image](https://user-images.githubusercontent.com/12329422/72287649-54b1cf00-363f-11ea-8f32-6112c439dfd2.png)


#### Notes
 * Users can now upload profile pictures, this is fixed by not treating the result as if it was a array. Since the result was already the blob data.
 * Sex is sent in the supported format: ints 

### Related Pull Requests 📢
* https://github.com/DevWars/devwars-api/pull/58