### PR TITLE
Twitch Connection Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DISCORD_CLIENT=
+TWITCH_CLIENT=
 
 API_URL=http://localhost:8080
 BASE_URL=http://localhost:3000

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,7 +45,7 @@
                 "ignoreTemplateLiterals": true
             }
         ],
-        "vetur.format.defaultFormatter.html": "none",
+        "vetur.format.defaultFormatter.html": "off",
         "prettier/prettier": 0
     }
 }

--- a/components/common/button.module.js
+++ b/components/common/button.module.js
@@ -26,7 +26,7 @@ export default {
                         href: this.$attrs.href,
                     },
                 },
-                this.$slots.default
+                this.$slots.default,
             );
         }
 
@@ -41,7 +41,7 @@ export default {
                     type: 'button',
                 },
             },
-            this.$slots.default
+            this.$slots.default,
         );
     },
 };

--- a/components/user/ConnectToTwitch.vue
+++ b/components/user/ConnectToTwitch.vue
@@ -1,10 +1,8 @@
 <template>
-    <div class="ConnectToDiscord">
-        <ButtonIcon v-if="!hasDiscord" :href="discordUrl" icon="fab fa-discord" class="discord"
-            >Connect Discord</ButtonIcon
-        >
-        <ButtonIcon v-else class="outline danger" icon="fab fa-discord" @click="removeProvider('DISCORD')"
-            >Disconnect Discord</ButtonIcon
+    <div class="ConnectToTwitch">
+        <ButtonIcon v-if="!hasTwitch" :href="twitchUrl" icon="fab fa-twitch" class="twitch">Connect Twitch</ButtonIcon>
+        <ButtonIcon v-else class="outline danger" icon="fab fa-twitch" @click="removeProvider('TWITCH')"
+            >Disconnect Twitch</ButtonIcon
         >
     </div>
 </template>
@@ -14,11 +12,11 @@ import { mapActions } from 'vuex';
 import userHasProvider from '../../utils/linkedAccounts';
 
 export default {
-    name: 'ConnectToDiscord',
+    name: 'ConnectToTwitch',
 
     data: () => {
         return {
-            discordUrl: `https://discordapp.com/api/oauth2/authorize?client_id=${process.env.discordClient}&redirect_uri=${process.env.apiUrl}/oauth/discord&response_type=code&scope=identify`,
+            twitchUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${process.env.twitchClient}&redirect_uri=${process.env.apiUrl}/oauth/twitch&response_type=code`,
         };
     },
 
@@ -31,8 +29,8 @@ export default {
             return this.$store.state.user.linkedAccounts;
         },
 
-        hasDiscord() {
-            return userHasProvider(this.links, 'DISCORD');
+        hasTwitch() {
+            return userHasProvider(this.links, 'TWITCH');
         },
     },
 
@@ -50,7 +48,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.discord {
+.twitch {
     width: 200px;
 }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,10 +5,11 @@ const webpack = require('webpack');
 const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
 const apiUrl = process.env.API_URL || 'http://localhost:8080';
 const discordClient = process.env.DISCORD_CLIENT || '';
+const twitchClient = process.env.TWITCH_CLIENT || '';
 
 module.exports = {
     mode: 'universal',
-    env: { baseUrl, apiUrl, discordClient },
+    env: { baseUrl, apiUrl, discordClient, twitchClient },
     /*
      ** Headers of the page
      */

--- a/pages/settings/connections.vue
+++ b/pages/settings/connections.vue
@@ -1,20 +1,14 @@
 <template>
-    <div class="group">
-        <Row>
-            <Column :md="8">
-                <h3>Connections</h3>
-            </Column>
-        </Row>
+    <div class="ConnectionsPage">
+        <h3>Connections</h3>
 
-        <Row>
-            <Column :md="8">
-                <ConnectToDiscord />
-            </Column>
+        <div class="connect">
+            <ConnectToDiscord/>
+        </div>
 
-            <Column :md="8">
-                <ConnectToTwitch />
-            </Column>
-        </Row>
+        <div class="connect">
+            <ConnectToTwitch/>
+        </div>
     </div>
 </template>
 
@@ -23,7 +17,17 @@ import ConnectToDiscord from '../../components/user/ConnectToDiscord';
 import ConnectToTwitch from '../../components/user/ConnectToTwitch';
 
 export default {
-    name: 'Connections',
+    name: 'ConnectionsPage',
     components: { ConnectToDiscord, ConnectToTwitch },
 };
 </script>
+
+<style lang="scss" scoped>
+@import 'utils.scss';
+
+.ConnectionsPage {
+    .connect + .connect {
+        margin-top: $grid-gutter-width;
+    }
+}
+</style>

--- a/pages/settings/connections.vue
+++ b/pages/settings/connections.vue
@@ -1,15 +1,29 @@
 <template>
-    <div>
-        <ConnectToDiscord/>
+    <div class="group">
+        <Row>
+            <Column :md="8">
+                <h3>Connections</h3>
+            </Column>
+        </Row>
+
+        <Row>
+            <Column :md="8">
+                <ConnectToDiscord />
+            </Column>
+
+            <Column :md="8">
+                <ConnectToTwitch />
+            </Column>
+        </Row>
     </div>
 </template>
 
-
 <script>
 import ConnectToDiscord from '../../components/user/ConnectToDiscord';
+import ConnectToTwitch from '../../components/user/ConnectToTwitch';
 
 export default {
     name: 'Connections',
-    components: { ConnectToDiscord },
+    components: { ConnectToDiscord, ConnectToTwitch },
 };
 </script>

--- a/store/game.js
+++ b/store/game.js
@@ -151,7 +151,7 @@ export const actions = {
             await dispatch(
                 'toast/add',
                 { type: 'success', message: `Thanks for signing up! See ya soon` },
-                { root: true }
+                { root: true },
             );
             await dispatch('navigate', '/game/confirmation', { root: true });
         } catch (e) {


### PR DESCRIPTION
### Overview
Users can now link there account with Twitch via the connections page. This looks fine when both accounts have been unlinked but do not look as good when both or a single one is linked. Worth having some time to reflect on design.

![image](https://user-images.githubusercontent.com/12329422/72684626-1a7e7c80-3ada-11ea-83e9-4e65fe667060.png)

![image](https://user-images.githubusercontent.com/12329422/72684628-1eaa9a00-3ada-11ea-9ade-2c86bb21fade.png)

#### Production Changes
Since this is a new service, a Twitch app will have to be registered in which you can gather the twitch client id and provide this within the .env file. https://dev.twitch.tv/console

### Notes
 * https://github.com/DevWars/devwars-api/pull/60
