### PR TITLE
Replace FontAwesome Pro with FontAwesome Free

### DIFF
--- a/components/mod/ModSidebar.vue
+++ b/components/mod/ModSidebar.vue
@@ -4,7 +4,7 @@
         <ul>
             <li>
                 <nuxt-link to="/mod/dashboard">
-                    <i class="fa fa-tachometer" />Dashboard
+                    <i class="fa fa-tachometer-alt" />Dashboard
                 </nuxt-link>
             </li>
             <li>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -55,14 +55,12 @@ export default {
             { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
             {
                 rel: 'stylesheet',
-                href:
-                    'https://fonts.googleapis.com/css?family=Montserrat:400,700|Roboto:300,400,500,700',
+                href: 'https://fonts.googleapis.com/css?family=Montserrat:400,700|Roboto:300,400,500,700',
             },
             {
                 rel: 'stylesheet',
-                href: 'https://pro.fontawesome.com/releases/v5.0.8/css/all.css',
-                integrity:
-                    'sha384-OGsxOZf8qnUumoWWSmTqXMPSNI9URpNYN35fXDb5Cv5jT6OR673ah1e5q+9xKTq6',
+                href: 'https://use.fontawesome.com/releases/v5.12.1/css/all.css',
+                integrity: 'sha384-v8BU367qNbs/aIZIxuivaU55N5GPF89WBerHoGA4QTcbUjYiLQtKdrfXnqAcXyTv',
                 crossorigin: 'anonymous',
             },
         ],

--- a/pages/docs.vue
+++ b/pages/docs.vue
@@ -669,7 +669,7 @@
 
                     <section>
                         <h3>Communication</h3>
-                        <div class="communications row row-normaled section">
+                        <Row class="communications normalize section">
                             <Column :sm="3">
                                 <i class="fa fa-microphone" />
                                 <p>Microphone</p>
@@ -685,7 +685,7 @@
                                 />
                                 <p>English</p>
                             </Column>
-                        </div>
+                        </Row>
 
                         <p>
                             It is required that you have a microphone so that


### PR DESCRIPTION
### Overview
With our annual renewal coming up, we can't afford to keep the Pro license of FontAwesome. This replaces the Pro version with the Free version. All existing icons not only work with the free version but have a nicer look without needing to make any additional changes.

### Related issues
[Fixes #31](https://github.com/DevWars/devwars.tv/issues/31)
