### PR TITLE
fix: change font-family for font awesome from pro to free

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -276,15 +276,15 @@ $zindex-modal                                       : 1050;
 ========================================================================== */
 .fa,
 .fas {
-  font-family: 'Font Awesome 5 Pro';
+  font-family: 'Font Awesome 5 Free';
 }
 
 .fal {
-    font-family: 'Font Awesome 5 Pro';
+    font-family: 'Font Awesome 5 Free';
 }
 
 .far {
-    font-family: 'Font Awesome 5 Pro';
+    font-family: 'Font Awesome 5 Free';
 }
 
 .fab {


### PR DESCRIPTION
font-family was still "Font Awesome 5 Pro" after Pro was dropped in PR #57.

Fixes #63

Couldn't find any `CONTRIBUTING.md`, so feel free to tell me if I did anything wrong and I'll fix it.