### PR TITLE
fix: hide schedules that are live from /games

### DIFF
--- a/pages/games.vue
+++ b/pages/games.vue
@@ -48,7 +48,7 @@ import Http from '../services/Http';
 import Tabs from '../components/Tabs';
 import Tag from '../components/Tag';
 import LargeGameDetail from '../components/game/LargeGameDetail';
-
+import nameFromStatus from '../utils/gameStatus';
 export default {
     name: 'Games',
 
@@ -70,8 +70,13 @@ export default {
             async handler(newSeason) {
                 this.season = Number(newSeason) || 3;
 
-                this.games = await Http.for('games/season').get(this.season);
+                const games = await Http.for('games/season').get(this.season);
 
+                if (games.length > 0) {
+                    this.games = games.filter(
+                        (game) => nameFromStatus(game.status) !== 'ACTIVE',
+                    );
+                }
                 if (!this.$route.query.game) {
                     this.viewing = await Http.for('games').get(
                         `${this.games[0].id}?players=${this.includePlayers}`,

--- a/pages/games.vue
+++ b/pages/games.vue
@@ -44,7 +44,6 @@
 </template>
 
 <script>
-import Http from '../services/Http';
 import Tabs from '../components/Tabs';
 import Tag from '../components/Tag';
 import LargeGameDetail from '../components/game/LargeGameDetail';
@@ -70,17 +69,21 @@ export default {
             async handler(newSeason) {
                 this.season = Number(newSeason) || 3;
 
-                const games = await Http.for('games/season').get(this.season);
+                const { data } = await this.$axios.get(
+                    `/games/season/${this.season}`,
+                );
 
-                if (games.length > 0) {
-                    this.games = games.filter(
+                if (data.length > 0) {
+                    this.games = data.filter(
                         (game) => nameFromStatus(game.status) !== 'ACTIVE',
                     );
                 }
                 if (!this.$route.query.game) {
-                    this.viewing = await Http.for('games').get(
-                        `${this.games[0].id}?players=${this.includePlayers}`,
+                    const { data } = await this.$axios.get(
+                        `/games/${this.games[0]}?players=${this.includePlayers}`,
                     );
+
+                    this.viewing = data;
                 }
             },
         },
@@ -89,9 +92,11 @@ export default {
             immediate: true,
             async handler(newGame) {
                 if (newGame) {
-                    this.viewing = await Http.for('games').get(
-                        `${newGame}?players=${this.includePlayers}`,
+                    const { data } = await this.$axios.get(
+                        `/games/${newGame}?players=${this.includePlayers}`,
                     );
+
+                    this.viewing = data;
                 }
             },
         },

--- a/pages/games.vue
+++ b/pages/games.vue
@@ -44,7 +44,6 @@
 </template>
 
 <script>
-import Http from '../services/Http';
 import Tabs from '../components/Tabs';
 import Tag from '../components/Tag';
 import LargeGameDetail from '../components/game/LargeGameDetail';
@@ -68,19 +67,24 @@ export default {
         '$route.query.season': {
             immediate: true,
             async handler(newSeason) {
-                this.season = Number(newSeason) || 3;
+                const season = Number(newSeason) || 3;
+                this.season = season;
 
-                const games = await Http.for('games/season').get(this.season);
+                const { data } = await this.$axios.get(
+                    `/games/season/${this.season}`,
+                );
 
-                if (games.length > 0) {
-                    this.games = games.filter(
+                if (data.length > 0) {
+                    this.games = data.filter(
                         (game) => nameFromStatus(game.status) !== 'ACTIVE',
                     );
                 }
                 if (!this.$route.query.game) {
-                    this.viewing = await Http.for('games').get(
-                        `${this.games[0].id}?players=${this.includePlayers}`,
+                    const { data } = await this.$axios.get(
+                        `/games/${this.games[0]}?players=${this.includePlayers}`,
                     );
+
+                    this.viewing = data;
                 }
             },
         },
@@ -89,9 +93,11 @@ export default {
             immediate: true,
             async handler(newGame) {
                 if (newGame) {
-                    this.viewing = await Http.for('games').get(
-                        `${newGame}?players=${this.includePlayers}`,
+                    const { data } = await this.$axios.get(
+                        `/games/${newGame}?players=${this.includePlayers}`,
                     );
+
+                    this.viewing = data;
                 }
             },
         },


### PR DESCRIPTION


### Overview

Resolves #67 by filtering the active games list, removing any games that are currently in the active state. This will stop poorly rendered games from showing up since not enough information is provided to display anything meaningful.