### PR TITLE
fix: make toast icons solid

### DIFF
--- a/components/toast/Toast.vue
+++ b/components/toast/Toast.vue
@@ -54,6 +54,7 @@ $toast-margin-y: 10px;
         margin-top: 3px;
         margin-right: 20px;
         font-size: $font-size-lg;
+        font-weight: 900;
     }
     .message {
         font-size: $font-size-base;


### PR DESCRIPTION
After transitioning from Pro to Free, the icons `check`, `exclamation-triangle`, and `times` were only available as Solid variants.

This broke them due to the fact that the `font-weight` of the icons was `normal` - `400` - which causes Font Awesome to use the Regular variant of the icon.

Solution is to give the Toast Icons a `font-weight` of `900`, making the icons of the Solid variant.

> It technically works when it has a `font-weight` of at least `501`, but the [Font Awesome use-guide](https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use) lists `900`.

***

It's possible other icons are experiencing this same issue, but I figured making this change to the [Icon component](https://github.com/DevWars/devwars.tv/blob/006be6417a58c7175c06a057b8a612a9ff0a396a/components/common/Icon.vue) could unnecessarily replace free and working Regular icons with Solid ones - there are 151 free Regular icons.

Would have done so if I could have thought of a way to tell if a icon was available as Free or not, but I could not, so this is the best I could come up with.

***

Tested on:
- Firefox 75.0
- Chrome 81.0.4044.92