### PR TITLE
Feature: Support for updating and changing usernames

### DIFF
--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -61,6 +61,10 @@ $input-label-offset: $input-padding-y * 2;
             opacity: 0.4;
         }
 
+        &:invalid {
+            color: $danger-color;
+        }
+
         &.empty:placeholder-shown ~ label,
         &:focus ~ label,
         &.valid ~ label,

--- a/pages/dashboard/_dashboard.vue
+++ b/pages/dashboard/_dashboard.vue
@@ -96,8 +96,14 @@ export default {
         },
 
         isModerator() {
-            const { role } = this.$store.state.user.user;
-            return role === 'MODERATOR' || role === 'ADMIN';
+            const { user } = this.$store.state.user;
+
+            if (user != null && user.user != null) {
+                const { role } = this.$store.state.user.user;
+                return role === 'MODERATOR' || role === 'ADMIN';
+            }
+
+            return false;
         },
     },
 };

--- a/pages/settings/account.vue
+++ b/pages/settings/account.vue
@@ -1,96 +1,121 @@
 <template>
-    <Row v-if="user">
-        <Column :sm="8">
-            <Input
-                v-model="user.username"
-                disabled
-                label="Username"
-                class="group"
-            />
+    <div v-if="user">
+        <Row class="row">
+            <Column :sm="8">
+                <h3>Username</h3>
+                <p v-if="!canUpdateUsername" class="update-username-text">
+                    Username change available on
+                    {{ updateUsernameAtDateTime }}
+                </p>
+                <Input
+                    :value="newUsername"
+                    :disabled="!canUpdateUsername"
+                    placeholder="Username"
+                    :label="usernameLabel"
+                    class="group"
+                    input-id="user-username"
+                    @input="onUsernameInput"
+                />
 
-            <h3>Email</h3>
-            <Input
-                v-model="emailCurrentPassword"
-                type="password"
-                input-id="email-current-password"
-                label="Current Password"
-                class="group"
-                required
-            />
-            <Input
-                v-model="user.email"
-                disabled
-                type="email"
-                label="Current Email"
-                class="group"
-            />
-            <Input
-                v-model="newEmail"
-                type="email"
-                label="New Email"
-                class="group"
-            />
+                <Button
+                    class="primary"
+                    :disabled="!isUsernameValid || !canUpdateUsername"
+                    :async-click="changeUsername"
+                >
+                    Change Username
+                </Button>
+            </Column>
+        </Row>
 
-            <Button
-                class="primary"
-                :disabled="!(newEmail && emailCurrentPassword)"
-                :async-click="changeEmail"
-            >
-                Change Email
-            </Button>
+        <Row class="row">
+            <Column :sm="8">
+                <h3>Email</h3>
+                <Input
+                    v-model="emailCurrentPassword"
+                    type="password"
+                    input-id="email-current-password"
+                    label="Current Password"
+                    class="group"
+                    required
+                />
+                <Input
+                    v-model="user.email"
+                    disabled
+                    type="email"
+                    label="Current Email"
+                    class="group"
+                />
+                <Input
+                    v-model="newEmail"
+                    type="email"
+                    label="New Email"
+                    class="group"
+                />
 
-            <h3>Password</h3>
-            <Input
-                v-model="currentPassword"
-                type="password"
-                input-id="current-password"
-                label="Current Password"
-                class="group"
-                required
-            />
-            <Input
-                v-model="newPassword"
-                type="password"
-                input-id="new-password"
-                label="New Password"
-                class="group"
-                required
-            />
-            <Input
-                v-model="newPasswordConfirmed"
-                type="password"
-                input-id="confirm-new-password"
-                label="Confirm New Password"
-                class="group"
-                required
-            />
+                <Button
+                    class="primary"
+                    :disabled="!(newEmail && emailCurrentPassword)"
+                    :async-click="changeEmail"
+                >
+                    Change Email
+                </Button>
+            </Column>
+        </Row>
+        <Row class="row">
+            <Column :sm="8">
+                <h3>Password</h3>
+                <Input
+                    v-model="currentPassword"
+                    type="password"
+                    input-id="current-password"
+                    label="Current Password"
+                    class="group"
+                    required
+                />
+                <Input
+                    v-model="newPassword"
+                    type="password"
+                    input-id="new-password"
+                    label="New Password"
+                    class="group"
+                    required
+                />
+                <Input
+                    v-model="newPasswordConfirmed"
+                    type="password"
+                    input-id="confirm-new-password"
+                    label="Confirm New Password"
+                    class="group"
+                    required
+                />
 
-            <Button
-                class="primary"
-                :disabled="
-                    !(
-                        currentPassword &&
-                        newPassword &&
-                        newPassword === newPasswordConfirmed
-                    )
-                "
-                :async-click="changePassword"
-            >
-                Change Password
-            </Button>
-        </Column>
-        <Column :sm="4" />
-    </Row>
+                <Button
+                    class="primary"
+                    :disabled="
+                        !(
+                            currentPassword &&
+                            newPassword &&
+                            newPassword === newPasswordConfirmed
+                        )
+                    "
+                    :async-click="changePassword"
+                >
+                    Change Password
+                </Button>
+            </Column>
+        </Row>
+    </div>
 </template>
 
 <script>
+import moment from 'moment';
+import { mapState } from 'vuex';
 import Input from '@/components/form/Input';
 
 export default {
     name: 'Accounts',
 
     components: { Input },
-
     data: () => {
         return {
             currentPassword: '',
@@ -98,26 +123,112 @@ export default {
             newPasswordConfirmed: '',
             emailCurrentPassword: '',
             newEmail: '',
+            newUsername: '',
         };
     },
 
     computed: {
-        user() {
-            return this.$store.state.user.user;
+        ...mapState({
+            user: (state) => state.user.user,
+        }),
+
+        isUsernameValid() {
+            const usernameRegexRequirement = /^[a-zA-Z0-9.-][A-z0-9.-_]{2,23}[a-zA-Z0-9.-]$/;
+            const result = usernameRegexRequirement.test(this.newUsername);
+
+            return result;
+        },
+
+        usernameLabel() {
+            const { lastUsernameUpdateAt } = this.user;
+
+            if (lastUsernameUpdateAt == null) return '';
+            return `last updated: ${moment(lastUsernameUpdateAt)
+                .utc()
+                .format('LLLL')}`;
+        },
+
+        /**
+         * Returns a displayable date time that can be used to notify the user
+         * when they are able to next update there username.
+         */
+        updateUsernameAtDateTime() {
+            const { lastUsernameUpdateAt } = this.user;
+
+            if (lastUsernameUpdateAt == null) return null;
+
+            return moment(lastUsernameUpdateAt)
+                .add(7, 'days')
+                .utc()
+                .format('LLLL');
+        },
+
+        /**
+         * Users are only ever able to update there username the first time for
+         * free but all other times can only occur after 7 days from the last
+         * time they changed there username.
+         *
+         * This policy is not applied to staff.
+         */
+        canUpdateUsername() {
+            const { lastUsernameUpdateAt } = this.user;
+
+            const dueDate = moment(lastUsernameUpdateAt)
+                .add(7, 'days')
+                .utc()
+                .toDate();
+
+            return (
+                this.isStaff ||
+                lastUsernameUpdateAt == null ||
+                dueDate < new Date()
+            );
+        },
+
+        isStaff() {
+            if (this.user == null) return false;
+            return this.user.role === 'ADMIN' || this.user.role === 'MODERATOR';
         },
     },
 
+    watch: {
+        user(newValue) {
+            if (newValue != null) this.newUsername = newValue.username;
+        },
+    },
+
+    mounted() {
+        if (this.user != null && this.user.username != null)
+            this.newUsername = this.user.username;
+    },
+
     methods: {
+        onUsernameInput(value) {
+            this.newUsername = value;
+        },
+
         /**
-         * Triggers a change email dispatch, with the new email and the currenet users password. If the
-         * details are correct and meet the server requirements, the users email will be updatd.
+         * Triggers a change username dispatch, with the new username. If the
+         * details are correct and meet the server requirements, the users
+         * username will be updated.
+         */
+        async changeUsername() {
+            await this.$store.dispatch('user/updateUsername', {
+                username: this.newUsername,
+            });
+        },
+
+        /**
+         * Triggers a change email dispatch, with the new email and the current
+         * users password. If the details are correct and meet the server
+         * requirements, the users email will be updated.
          *
          * Regardless of update, all fields will be emptied.
          */
         async changeEmail() {
-            await this.$store.dispatch('user/email', {
-                email: this.newEmail,
+            await this.$store.dispatch('user/updateEmail', {
                 password: this.emailCurrentPassword,
+                email: this.newEmail,
             });
 
             this.emailCurrentPassword = '';
@@ -131,7 +242,7 @@ export default {
          * Regardless of update, all fields will be emptied.
          */
         async changePassword() {
-            await this.$store.dispatch('user/password', {
+            await this.$store.dispatch('user/updatePassword', {
                 oldPassword: this.currentPassword,
                 newPassword: this.newPassword,
             });
@@ -143,3 +254,16 @@ export default {
     },
 };
 </script>
+
+<style lang="scss" scoped>
+@import 'utils.scss';
+
+.row {
+    margin-bottom: 25px;
+}
+
+.update-username-text {
+    padding-bottom: 10px;
+    color: $danger-color;
+}
+</style>

--- a/store/user.js
+++ b/store/user.js
@@ -200,7 +200,7 @@ export const actions = {
         }
     },
 
-    async password({ dispatch }, data) {
+    async updatePassword({ dispatch }, data) {
         try {
             await Http.for('auth/reset/password').put(data);
 
@@ -212,7 +212,23 @@ export const actions = {
         }
     },
 
-    async email({ dispatch, commit, state }, { password, email }) {
+    /**
+     * Requests to update the given users username on the server, if all goes
+     * well, the username will be updated within the store and reflected around
+     * the site. Otherwise the toast will show the related server error.
+     *
+     * @param username The new users username that is being updated.
+     */
+    async updateUsername({ dispatch, commit, state }, { username }) {
+        try {
+            await this.$axios.put(`users/${state.user.id}`, { username });
+            commit('user', Object.assign(state.user, { username }));
+        } catch (e) {
+            dispatch('toast/error', e.response.data, { root: true });
+        }
+    },
+
+    async updateEmail({ dispatch, commit, state }, { password, email }) {
         try {
             const data = await Http.for('auth/reset').post('email', {
                 password,


### PR DESCRIPTION
### Overview 

The account page now actively supports updating the given users username. The username button will not be activated until the username meets the servers update requirements. Displaying information about when the last updated occurred.

This update goes in hand with the server changes required to support username changing here:  https://github.com/DevWars/devwars-api/pull/167

#### Account page after updating a username as a standard user

After a standard user changes there username and begins the waiting period, they will be warned that they are unable to change there username until the given date. This will not be shown for staff members since they are not enforced by the policy.

![image](https://user-images.githubusercontent.com/12329422/80313972-43539380-87e6-11ea-8811-2cc150f680b2.png)


#### Account page after updating username as staff member

![image](https://user-images.githubusercontent.com/12329422/80313981-5cf4db00-87e6-11ea-8052-fa5cc8550d90.png)

