### PR TITLE
feat: support for banning and unbanning a user in the moderation panel

### DIFF
--- a/components/dashboard/Moderation.vue
+++ b/components/dashboard/Moderation.vue
@@ -1,15 +1,20 @@
 <template>
-    <DashboardCard class="Moderation scrollable" title="Moderation" icon="gavel">
+    <DashboardCard
+        class="Moderation scrollable"
+        title="Moderation"
+        icon="gavel"
+    >
         <div class="main">
-            <Column :xs="2" class="no-gutter status">
-                <Button
-                    :disabled="!isAdmin"
-                    class="danger"
-                    @click="deleteUser"
-                >
-                    Delete
-                </Button>
-            </Column>
+            <Button :disabled="!isAdmin" class="danger" @click="deleteUser">
+                Delete
+            </Button>
+
+            <Button v-if="!currentUserBanned" class="danger" @click="banUser">
+                Ban
+            </Button>
+            <Button v-else class="danger" @click="removeUserBan">
+                Remove Ban
+            </Button>
         </div>
     </DashboardCard>
 </template>
@@ -40,6 +45,10 @@ export default {
             const { role } = this.$store.state.user.user;
             return role === 'MODERATOR';
         },
+
+        currentUserBanned() {
+            return this.user.role === 'BANNED';
+        },
     },
 
     methods: {
@@ -56,6 +65,38 @@ export default {
                 this.$router.push('/dashboard');
             }
         },
+
+        async banUser() {
+            const { username, id } = this.user;
+
+            const result = await this.$open(DeleteModal, {
+                title: `Ban User ${username}?`,
+                confirm: 'Ban User',
+                description: `Are you sure you want ban the user ${username}? Doing so will kick them out there current season.`,
+            });
+
+            if (result) {
+                const body = { role: 'BANNED' };
+                await this.$axios.put(`/users/${id}`, body);
+                this.user.role = body.role;
+            }
+        },
+
+        async removeUserBan() {
+            const { username, id } = this.user;
+
+            const result = await this.$open(DeleteModal, {
+                title: `Remove Ban From User ${username}?`,
+                confirm: 'Remove Ban',
+                description: `Are you sure you want remove the ban from the user ${username}? This will allow them to login again.`,
+            });
+
+            if (result) {
+                const body = { role: 'USER' };
+                await this.$axios.put(`/users/${id}`, body);
+                this.user.role = body.role;
+            }
+        },
     },
 };
 </script>
@@ -67,9 +108,13 @@ export default {
     /deep/ {
         .main {
             @extend %flex-justify;
-            width: 100%;
             padding: $grid-gutter-width;
             border-bottom: 1px solid $divider-color;
+            float: left;
+
+            button {
+                margin-right: 10px;
+            }
         }
 
         .actions {


### PR DESCRIPTION
### Overview
The moderation panel on a users page now supports the banning and unbanning users. The specified button is based on moderation support and switches based on if the user is banned or not banned.

![image](https://user-images.githubusercontent.com/12329422/80611081-0d0a5400-8a32-11ea-8cd3-8ff2d590c500.png)

![image](https://user-images.githubusercontent.com/12329422/80611421-7e4a0700-8a32-11ea-84c9-57cb992952fa.png)

![image](https://user-images.githubusercontent.com/12329422/80611433-8144f780-8a32-11ea-9ecb-f8d4c3abb670.png)

![image](https://user-images.githubusercontent.com/12329422/80611442-843fe800-8a32-11ea-9a15-6b8b6fd2113b.png)

