### PR TITLE
feat: games and schedules now use paging implementation

### DIFF
--- a/components/mod/ListingFilters.vue
+++ b/components/mod/ListingFilters.vue
@@ -1,8 +1,10 @@
 <template>
     <div class="ListingFilters">
         <div class="main">
-            <Select>
-                <option value="Infinity" selected>Show All</option>
+            <Select @change="(e) => $emit('change', e)">
+                <option v-for="x in options" :key="x.value" :value="x.value">
+                    {{ x.name }}
+                </option>
             </Select>
         </div>
 
@@ -18,6 +20,18 @@ import Select from '@/components/form/Select';
 export default {
     name: 'ListingFilters',
     components: { Select },
+
+    props: {
+        options: {
+            type: Array,
+            required: false,
+            default: () => [{ name: 'Show All', value: 1 }],
+        },
+    },
+
+    data() {
+        return {};
+    },
 };
 </script>
 

--- a/pages/dashboard/_dashboard.vue
+++ b/pages/dashboard/_dashboard.vue
@@ -98,9 +98,8 @@ export default {
         isModerator() {
             const { user } = this.$store.state.user;
 
-            if (user != null && user.user != null) {
-                const { role } = this.$store.state.user.user;
-                return role === 'MODERATOR' || role === 'ADMIN';
+            if (user != null && user != null) {
+                return user.role === 'MODERATOR' || user.role === 'ADMIN';
             }
 
             return false;

--- a/pages/games.vue
+++ b/pages/games.vue
@@ -85,13 +85,13 @@ export default {
 
         try {
             const { data } = await $axios.get(
-                `/games/season/${query.season}?first=10&status=ended`,
+                `/games?season=${query.season}&first=10&status=ended`,
             );
 
             const games = data.data;
             let viewing = null;
 
-            // If the given game that the user was sent too is not on the
+            // If the given game that the ser was sent too is not on the
             // first page of the season, load that game directly and shift
             // it to the top of the games list, making it shown in the
             // sidebar and highlighted (regardless of this the game would
@@ -178,7 +178,7 @@ export default {
                 this.season = Number(season);
 
                 const { data } = await this.$axios.get(
-                    `/games/season/${this.season}?first=10&status=ended`,
+                    `/games?season=${this.season}&first=10&status=ended`,
                 );
 
                 // if a route update is triggered, requiring the regathering of
@@ -244,9 +244,8 @@ export default {
             const { pagination } = this.games;
             const before = pagination.previous;
 
-            const { data } = await this.$axios.get(
-                `games/season/${this.season}?first=10&before=${before}&status=ended`,
-            );
+            const url = `games?season=${this.season}&first=10&before=${before}&status=ended`;
+            const { data } = await this.$axios.get(url);
 
             this.games = data;
         },
@@ -260,7 +259,7 @@ export default {
             const after = pagination.next;
 
             const { data } = await this.$axios.get(
-                `games/season/${this.season}?first=10&after=${after}&status=ended`,
+                `games?season=${this.season}?first=10&after=${after}&status=ended`,
             );
 
             this.games = data;

--- a/pages/mod/games.vue
+++ b/pages/mod/games.vue
@@ -6,7 +6,10 @@
             </ButtonIcon>
         </PanelHeader>
 
-        <ListingFilters />
+        <ListingFilters
+            :options="gamesFilterOptions"
+            @change="onGameFilterChange"
+        />
 
         <Table>
             <tr slot="head">
@@ -18,7 +21,7 @@
                 <th>&nbsp;</th>
             </tr>
 
-            <tr v-for="game in games" :key="game.id">
+            <tr v-for="game in games.data" :key="game.id">
                 <td>{{ game.createdAt | moment('MM/DD/YYYY') }}</td>
                 <td>
                     <span
@@ -41,12 +44,21 @@
             </tr>
         </Table>
 
-        <Pagination />
+        <Pagination
+            :page="page"
+            :per-page="10"
+            :can-next="canPageNextGames"
+            :can-previous="canPagePreviousGames"
+            @next="next"
+            @previous="previous"
+        />
     </div>
 </template>
 
 <script>
+import { isNil } from 'lodash';
 import { names } from '../../utils/auth';
+
 import CreateGameModal from '@/components/modal/CreateGameModal';
 import PanelHeader from '@/components/mod/PanelHeader';
 import ListingFilters from '@/components/mod/ListingFilters';
@@ -61,15 +73,72 @@ export default {
         auth: names.MODERATOR,
     },
     components: { PanelHeader, ListingFilters, Table, Pagination },
-    async fetch({ store }) {
-        await store.dispatch('game/all');
+
+    async asyncData({ query, error, $axios }) {
+        try {
+            const { data } = await $axios.get('/games?first=10');
+            return { games: data, page: 0 };
+        } catch (e) {
+            error({
+                statusCode: e.response.status,
+                description: e.response.data.error,
+                message: e.response.statusText,
+            });
+        }
     },
+
+    data() {
+        return {
+            gameFilter: 'all',
+
+            gamesFilterOptions: [
+                { name: 'Show All', value: 'all' },
+                { name: 'Scheduled', value: 'scheduled' },
+                { name: 'Active', value: 'active' },
+                { name: 'Ended', value: 'ended' },
+            ],
+        };
+    },
+
     computed: {
-        games() {
-            return this.$store.state.game.all;
+        /**
+         * Returns true if we can page forward in the games list, this ensures
+         * we have the next page link and the next page will not be empty.
+         */
+        canPageNextGames() {
+            if (isNil(this.games?.pagination?.next)) return false;
+            return (
+                this.games?.pagination?.next != null &&
+                this.games?.data?.length >= 10
+            );
+        },
+
+        /**
+         * Returns true if we can page backward, ensuring that we are not the
+         * first page.
+         */
+        canPagePreviousGames() {
+            if (isNil(this.games?.pagination?.previous)) return false;
+            return this.games?.pagination?.previous != null;
         },
     },
     methods: {
+        async onGameFilterChange(e) {
+            try {
+                this.gameFilter = e;
+                let url = '/games?first=10';
+
+                if (this.gameFilter !== 'all')
+                    url += `&status=${this.gameFilter}`;
+
+                this.games = (await this.$axios.get(url)).data;
+
+                this.page = 0;
+            } catch (error) {
+                this.$store.dispatch('toast/error', e.response.data);
+            }
+        },
+
         nameFromStatus,
         async createGame() {
             const [game] = await this.$open(CreateGameModal, {});
@@ -82,6 +151,38 @@ export default {
                 path: '/mod/game/details',
                 params: { game: game.id },
             });
+        },
+
+        /**
+         * Execute a page backward.
+         */
+        async previous() {
+            this.page -= 1;
+            const { pagination } = this.games;
+            const before = pagination.previous;
+
+            let url = `games?first=10&before=${before}`;
+            if (this.gameFilter !== 'all') url += `&status=${this.gameFilter}`;
+
+            const { data } = await this.$axios.get(url);
+
+            this.games = data;
+        },
+
+        /**
+         * Execute a page forward.
+         */
+        async next() {
+            this.page += 1;
+            const { pagination } = this.games;
+            const after = pagination.next;
+
+            let url = `games?first=10&after=${after}`;
+            if (this.gameFilter !== 'all') url += `&status=${this.gameFilter}`;
+
+            const { data } = await this.$axios.get(url);
+
+            this.games = data;
         },
     },
 };

--- a/pages/mod/schedules.vue
+++ b/pages/mod/schedules.vue
@@ -6,7 +6,10 @@
             </ButtonIcon>
         </PanelHeader>
 
-        <ListingFilters />
+        <ListingFilters
+            :options="scheduleFilterOptions"
+            @change="onScheduleFilterChange"
+        />
 
         <Table>
             <tr slot="head">
@@ -17,7 +20,7 @@
                 <th>&nbsp;</th>
             </tr>
 
-            <tr v-for="schedule in schedules" :key="schedule.id">
+            <tr v-for="schedule in schedules.data" :key="schedule.id">
                 <td>{{ schedule.startTime | moment('MM/DD/YYYY') }}</td>
                 <td>
                     <span
@@ -41,13 +44,24 @@
                 </td>
             </tr>
         </Table>
+
+        <Pagination
+            :page="page"
+            :per-page="10"
+            :can-next="canPageNextSchedule"
+            :can-previous="canPagePreviousSchedule"
+            @next="next"
+            @previous="previous"
+        />
     </div>
 </template>
 
 <script>
+import { isNil } from 'lodash';
 import { names } from '../../utils/auth';
 import CreateScheduleModal from '../../components/modal/CreateScheduleModal.vue';
 import PanelHeader from '@/components/mod/PanelHeader';
+import Pagination from '@/components/Pagination';
 import ListingFilters from '@/components/mod/ListingFilters';
 import Table from '@/components/Table';
 
@@ -60,15 +74,54 @@ export default {
         auth: names.MODERATOR,
     },
 
-    components: { PanelHeader, ListingFilters, Table },
+    components: { PanelHeader, ListingFilters, Table, Pagination },
 
-    async fetch({ store }) {
-        await store.dispatch('game/schedules');
+    async asyncData({ query, error, $axios }) {
+        try {
+            const { data } = await $axios.get('/schedules?first=10');
+            return { schedules: data, page: 0 };
+        } catch (e) {
+            error({
+                statusCode: e.response.status,
+                description: e.response.data.error,
+                message: e.response.statusText,
+            });
+        }
+    },
+
+    data() {
+        return {
+            scheduleFilter: 'all',
+
+            scheduleFilterOptions: [
+                { name: 'Show All', value: 'all' },
+                { name: 'Scheduled', value: 'scheduled' },
+                { name: 'Active', value: 'active' },
+                { name: 'Ended', value: 'ended' },
+            ],
+        };
     },
 
     computed: {
-        schedules() {
-            return this.$store.state.game.schedules;
+        /**
+         * Returns true if we can page forward in the schedule list, this ensures
+         * we have the next page link and the next page will not be empty.
+         */
+        canPageNextSchedule() {
+            if (isNil(this.schedules?.pagination?.next)) return false;
+            return (
+                this.schedules?.pagination?.next != null &&
+                this.schedules?.data?.length >= 10
+            );
+        },
+
+        /**
+         * Returns true if we can page backward, ensuring that we are not the
+         * first page.
+         */
+        canPagePreviousSchedule() {
+            if (isNil(this.schedules?.pagination?.previous)) return false;
+            return this.schedules?.pagination?.previous != null;
         },
     },
 
@@ -76,6 +129,56 @@ export default {
         nameFromStatus,
         async createSchedule() {
             await this.$open(CreateScheduleModal, {});
+        },
+
+        async onScheduleFilterChange(e) {
+            try {
+                this.scheduleFilter = e;
+                let url = '/schedules?first=10';
+
+                if (this.scheduleFilter !== 'all')
+                    url += `&status=${this.scheduleFilter}`;
+
+                this.schedules = (await this.$axios.get(url)).data;
+
+                this.page = 0;
+            } catch (error) {
+                this.$store.dispatch('toast/error', e.response.data);
+            }
+        },
+
+        /**
+         * Execute a page backward.
+         */
+        async previous() {
+            this.page -= 1;
+            const { pagination } = this.schedules;
+            const before = pagination.previous;
+
+            let url = `schedules?first=10&before=${before}`;
+            if (this.scheduleFilter !== 'all')
+                url += `&status=${this.scheduleFilter}`;
+
+            const { data } = await this.$axios.get(url);
+
+            this.schedules = data;
+        },
+
+        /**
+         * Execute a page forward.
+         */
+        async next() {
+            this.page += 1;
+            const { pagination } = this.schedules;
+            const after = pagination.next;
+
+            let url = `schedules?first=10&after=${after}`;
+            if (this.scheduleFilter !== 'all')
+                url += `&status=${this.scheduleFilter}`;
+
+            const { data } = await this.$axios.get(url);
+
+            this.schedules = data;
         },
     },
 };

--- a/store/game.js
+++ b/store/game.js
@@ -128,8 +128,8 @@ export const actions = {
 
     async active({ commit }) {
         try {
-            const [active] = await Http.for('schedules/status/active').get();
-            commit('active', active);
+            const { data } = await Http.for('schedules?status=active').get();
+            commit('active', data[0]);
         } catch (e) {
             commit('active', null);
         }
@@ -137,8 +137,8 @@ export const actions = {
 
     async upcoming({ commit, dispatch }) {
         try {
-            const upcoming = await Http.for('schedules/status/scheduled').get();
-            commit('upcoming', upcoming);
+            const { data } = await Http.for('schedules?status=scheduled').get();
+            commit('upcoming', data);
         } catch (e) {
             dispatch('toast/error', e.response.data, { root: true });
         }


### PR DESCRIPTION
### Overview
Updated the routes that now use the paging implementation and updated the removed routes to use the paging implementation. (Anything that was using /active or related status endpoints now uses the paging implementation.) 