### PR TITLE
fix: twitch iframe now contains parent (hostname) as required

### DIFF
--- a/components/game/NowShowing.vue
+++ b/components/game/NowShowing.vue
@@ -7,7 +7,7 @@
         <div class="now-showing">
             <div class="embed-video">
                 <iframe
-                    src="https://player.twitch.tv/?channel=devwars"
+                    :src="twitchUrl"
                     frameborder="0"
                     allowfullscreen="true"
                     scrolling="no"
@@ -38,9 +38,25 @@ import HomeCard from '@/components/HomeCard';
 export default {
     name: 'NowShowing',
     components: { HomeCard, RegistrationButtons },
+
     computed: {
+        twitchUrl() {
+            return `https://player.twitch.tv/?channel=devwars&parent=${this.extractHostname(
+                process.env.baseUrl,
+            )}`;
+        },
         schedule() {
             return this.$store.state.game.active;
+        },
+    },
+
+    methods: {
+        extractHostname(url) {
+            const hostname = url.includes('//')
+                ? url.split('/')[2]
+                : url.split('/')[0];
+
+            return hostname.split(':')[0].split('?')[0];
         },
     },
 };


### PR DESCRIPTION
### Overview

Twitch updated its requirements for rendering iframes of its streams, ensuring a parent is provided of the current hostname. If not done correctly the stream will not render.

This is using the hostname of the BASE_URL environment variable.